### PR TITLE
fix: public_member_api_docs linter rule not working

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+- Fix the public_member_api_docs rule not working
+
 ## 0.0.4
 
 - Fixed another issue that prevented importing the rules defined by this package due to wrong

--- a/lib/packages.yaml
+++ b/lib/packages.yaml
@@ -7,4 +7,4 @@ linter:
 
 analyzer:
   errors:
-    public_member_api_docs: warning
+    public_member_api_docs: info

--- a/lib/packages.yaml
+++ b/lib/packages.yaml
@@ -2,7 +2,8 @@ include: package:flutter_lint_rules/core.yaml
 
 linter:
   rules:
-   avoid_print: false
+    avoid_print: false
+    public_member_api_docs: true
 
 analyzer:
   errors:


### PR DESCRIPTION
## Description
The `public_member_api_docs` linter rule wasn't working because it wasn't added to the set of enabled linter rules.